### PR TITLE
Enable monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Este projeto demonstra um ambiente de Lakehouse on-premises utilizando Docker Co
 - **Hive Metastore** com banco PostgreSQL
 - **Spark** com suporte a Delta Lake (master e worker)
 - **Trino** configurado para acessar o Hive Metastore e o MinIO
+- **Prometheus** e **Grafana** para observabilidade do ambiente
 
 ## Estrutura de diretórios
 
@@ -14,6 +15,7 @@ Este projeto demonstra um ambiente de Lakehouse on-premises utilizando Docker Co
 - `spark/conf` – configurações do Spark (ex.: `spark-defaults.conf`)
 - `trino/catalog` – catálogos do Trino
 - `scripts` – utilitários para iniciar ou parar o ambiente
+- `monitoring/prometheus.yml` – configuração do Prometheus
 
 ## Uso
 
@@ -25,6 +27,10 @@ Para iniciar todos os serviços em segundo plano utilize o script:
 
 A interface do MinIO estará disponível em `http://localhost:9001` (usuário `minio` / senha `minio123`).
 O Spark Master estará em `http://localhost:8080` e o Trino em `http://localhost:8088`.
+O Prometheus pode ser acessado em `http://localhost:9090` e o Grafana em `http://localhost:3000`.
+
+Cada serviço possui limites e reservas de CPU e memória definidos no `docker-compose.yml`.
+Esses valores podem ser ajustados conforme a capacidade do seu ambiente.
 
 Quando quiser interromper e remover os serviços execute:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       - ./minio/data:/data
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   postgres:
     image: postgres:13
@@ -25,6 +33,14 @@ services:
       - ./postgres/data:/var/lib/postgresql/data
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   hive-metastore:
     image: bitnami/hive-metastore:latest
@@ -40,6 +56,14 @@ services:
       - postgres
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   spark-master:
     image: bitnami/spark:latest
@@ -52,6 +76,14 @@ services:
       - ./spark/conf:/opt/bitnami/spark/conf
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   spark-worker:
     image: bitnami/spark:latest
@@ -66,6 +98,14 @@ services:
       - ./spark/conf:/opt/bitnami/spark/conf
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '1.0'
+          memory: 1G
 
   trino:
     image: trinodb/trino:latest
@@ -77,6 +117,60 @@ services:
       - hive-metastore
     networks:
       - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '1.0'
+          memory: 1G
 
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+  node-exporter:
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    networks:
+      - lakehouse
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
 networks:
   lakehouse:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']


### PR DESCRIPTION
## Summary
- add CPU and memory reservations for all services
- document that resources can be tuned
- run Prometheus, Grafana and node-exporter containers

## Testing
- `docker-compose config` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*
- `python3 - <<'PY' ...` *(fails: No module named 'yaml')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685ee954dfb48326b8f55ff2ea55db42