### PR TITLE
Add SQL Server ingestion example

### DIFF
--- a/spark/jobs/ingest_sqlserver.py
+++ b/spark/jobs/ingest_sqlserver.py
@@ -1,0 +1,36 @@
+from pyspark.sql import SparkSession
+
+
+def main():
+    """Ingest data from SQL Server and write to Delta Lake"""
+    spark = (
+        SparkSession.builder.appName("SQLServerIngest")
+        .config("spark.jars.packages", "com.microsoft.sqlserver:mssql-jdbc:10.2.0.jre8")
+        .getOrCreate()
+    )
+
+    jdbc_url = (
+        "jdbc:sqlserver://SQLSERVER_HOST:1433;databaseName=DB_NAME"
+    )
+
+    connection_properties = {
+        "user": "YOUR_USER",
+        "password": "YOUR_PASSWORD",
+        "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+    }
+
+    table = "dbo.your_table"
+
+    df = spark.read.jdbc(url=jdbc_url, table=table, properties=connection_properties)
+
+    (
+        df.write.format("delta")
+        .mode("overwrite")
+        .save("s3a://lakehouse/sqlserver/your_table")
+    )
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Spark job to ingest SQL Server data via JDBC

## Testing
- `python -m py_compile spark/jobs/ingest_sqlserver.py`

------
https://chatgpt.com/codex/tasks/task_e_685eeee77c0c8326ace3710aa996c8e1