### PR TITLE
Fix hive-metastore image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Este repositório provê um exemplo simples de ambiente **Lakehouse** rodando lo
 
 - **MinIO** atuando como storage compatível com S3
 - **PostgreSQL** usado pelo **Hive Metastore**
+- **Hive Metastore** fornecido pela imagem `trinodb/testing-hive-metastore`
 - **Spark** (master e worker) com suporte ao **Delta Lake**
 - **Trino** para consulta aos dados
 - **Prometheus**, **Grafana** e **Node Exporter** para observação

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
           memory: 512M
 
   hive-metastore:
-    image: bitnami/hive-metastore:latest
+    image: trinodb/testing-hive-metastore:latest
     ports:
       - "9083:9083"
     environment:


### PR DESCRIPTION
## Summary
- use a public image for Hive Metastore
- document Hive Metastore image in README

## Testing
- `docker compose version` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ff6f56d90832690571c1d51c0971d