### PR TITLE
Fix hive metastore image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este repositório provê um exemplo simples de ambiente **Lakehouse** rodando lo
 
 - **MinIO** atuando como storage compatível com S3
 - **PostgreSQL** usado pelo **Hive Metastore**
-- **Hive Metastore** fornecido pela imagem `trinodb/testing-hive-metastore`
+- **Hive Metastore** fornecido pela imagem `bitnami/hive-metastore`
 - **Spark** (master e worker) com suporte ao **Delta Lake**
 - **Trino** para consulta aos dados
 - **Prometheus**, **Grafana** e **Node Exporter** para observação

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
           memory: 512M
 
   hive-metastore:
-    image: trinodb/testing-hive-metastore:latest
+    image: bitnami/hive-metastore:latest
     ports:
       - "9083:9083"
     environment:


### PR DESCRIPTION
## Summary
- use `bitnami/hive-metastore` instead of the unavailable `trinodb/testing-hive-metastore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ff8847bcc8326a9c6f672d088ff57