### PR TITLE
Atualiza imagem do Hive Metastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este repositório provê um exemplo simples de ambiente **Lakehouse** rodando lo
 
 - **MinIO** atuando como storage compatível com S3
 - **PostgreSQL** usado pelo **Hive Metastore**
-- **Hive Metastore** fornecido pela imagem `bitnami/hive-metastore`
+- **Hive Metastore** fornecido pela imagem `apache/hive:3.1.3`
 - **Spark** (master e worker) com suporte ao **Delta Lake**
 - **Trino** para consulta aos dados
 - **Prometheus**, **Grafana** e **Node Exporter** para observação

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
           memory: 512M
 
   hive-metastore:
-    image: bitnami/hive-metastore:latest
+    image: apache/hive:3.1.3
     ports:
       - "9083:9083"
     environment:


### PR DESCRIPTION
## Summary
- update hive-metastore image to `apache/hive:3.1.3`
- adjust README to reference new image

## Testing
- `docker compose config` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffa2006c88326b6e9cd8957e9e7cb