### PR TITLE
Atualizar README para Português

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Lakehouse Athena
+
+Este repositório fornece um exemplo de stack "lakehouse" local usando **Apache Spark** e **MinIO** para armazenamento de objetos. É destinado a experimentos com Spark, tabelas Delta e armazenamento compatível com S3.
+
+## Visão Geral do Repositório
+
+- `docker-compose.yml` – orquestração dos serviços
+- `config/` – modelos de configuração do Spark
+- `images/` – Dockerfiles utilizados nas imagens
+- `jobs/` – notebooks e scripts de exemplo
+- `makefile` – comandos de apoio para operação da stack
+
+## Requisitos
+
+- [Docker](https://docs.docker.com/get-docker/) com Docker Compose
+- [make](https://www.gnu.org/software/make/) para executar o *makefile*
+
+## Configuração Inicial
+
+1. **Crie um arquivo `.env`** na raiz do projeto com ao menos as variáveis abaixo:
+
+   ```env
+   MINIO_ROOT_USER=minio
+   MINIO_ROOT_PASSWORD=miniopass
+   MINIO_URI=http://minio:9000
+   AWS_ACCESS_KEY_ID=$MINIO_ROOT_USER
+   AWS_SECRET_ACCESS_KEY=$MINIO_ROOT_PASSWORD
+   ```
+   Esses valores são utilizados para gerar `config/spark-defaults.conf` e executar os contêineres.
+
+2. **Inicie a stack**:
+
+   ```bash
+   make up
+   ```
+   O alvo `make up` verifica/cria a rede `datalake-network`, gera a configuração do Spark e sobe os serviços definidos no `docker-compose.yml`.
+
+3. **Pare a stack**:
+
+   ```bash
+   make down
+   ```
+
+## Utilização
+
+Acesse o Jupyter Notebook em [http://localhost:8888](http://localhost:8888). A autenticação vem desabilitada por padrão. Há um notebook de exemplo em `jobs/teste.ipynb` demonstrando a escrita de uma pequena tabela Delta no MinIO.
+
+MinIO fica disponível em:
+
+- **API**: `http://localhost:9000`
+- **Console**: `http://localhost:9001`
+
+Utilize as credenciais do arquivo `.env` para fazer login.
+
+## Customização
+
+- **Configuração do Spark**: edite `config/spark-defaults.conf.template` e execute `make build` ou `make up` para reconstruir.
+- **Imagens Docker**: os Dockerfiles em `images/` podem ser adaptados para instalar dependências adicionais.
+- **Jobs/Notebooks**: adicione seus notebooks ou scripts Spark em `jobs/`.
+
+## Licença
+
+Este projeto é fornecido "no estado em que se encontra" para fins educacionais.


### PR DESCRIPTION
## Summary
- traduz README para português e inclui passos de configuração

## Testing
- `make build` *(falha: .env ausente)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68647ca3bf4c83269652826bd4e923d0