### PR TITLE
Update README with architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Este repositório fornece um exemplo de stack "lakehouse" local usando **Apache Spark** e **MinIO** para armazenamento de objetos. É destinado a experimentos com Spark, tabelas Delta e armazenamento compatível com S3.
 
+## Arquitetura
+
+O diagrama a seguir ilustra como os contêineres se conectam para formar a stack.
+
+![Arquitetura do projeto](image.png)
+
 ## Visão Geral do Repositório
 
 - `docker-compose.yml` – orquestração dos serviços


### PR DESCRIPTION
## Summary
- document stack architecture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'airflow')*

------
https://chatgpt.com/codex/tasks/task_e_68703c1ec58083269f09627ba9984be4